### PR TITLE
44 forecast integration

### DIFF
--- a/group7/lib/features/current_aqi/aqi_model.dart
+++ b/group7/lib/features/current_aqi/aqi_model.dart
@@ -1,20 +1,35 @@
 import "aqi_style.dart";
 
 
-// Homepage class, add more attributes to account for more data
+/// Homepage class, add more attributes to account for more data
+/// * [general] - The main AQI value
+/// * [pm2_5]  - Recorded pm2_5 value
+/// * [pm10]  - Recorded pm10 value
+/// * [city]  - The city defined by the request
+/// * [timestamp] - When the request was made
+/// * [threeDayForecast] - A list of [ForecastDay]:s  for today(index 0) and 3 upcoming days
+/// 
+/// ### Example of [threeDayForecast]
+/// * threeDayForecast[0] - will return all the forecasts for today + date
+/// * threeDayForecast[0].pm2_5.avg - will return the avg pm2.5 for today
+/// * threeDayForecast[1].date - will return the date for tomorrow
+/// 
+
 class AqiModel {
   final int general;
   final int pm2_5;
   final int pm10;
   final String city;
   final DateTime timestamp;
+  final List<ForecastDay> threeDayForecast;
 
   AqiModel({
     required this.general,
     required this.pm2_5,  
     required this.pm10,  
     required this.city, 
-    required this.timestamp}
+    required this.timestamp,
+    required this.threeDayForecast}
   );
 
 
@@ -32,13 +47,58 @@ class AqiModel {
       pm10: json["data"]["iaqi"]["pm10"]["v"],
       city: json["data"]["city"]["name"],
       timestamp: DateTime.now(),
+      threeDayForecast : getForecastFromJson(json),
     );
   }
 
+  ///Extracts Forecast based on API [json] response
+  static List<ForecastDay> getForecastFromJson(Map<String, dynamic> json) {
+    List<ForecastDay> forecastDays = [];
 
-  AqiStyle get style => AqiStyle.fromAqi(general);
+    for(var i=0; i < 4; i++){
+      String date = json["data"]["forecast"]["daily"]["pm10"][i+2]["day"];
+
+      //Check if index out of range(missing data)
+      if( 
+        i+2 >= json["data"]["forecast"]["daily"]["pm25"].length || 
+        i+2 >= json["data"]["forecast"]["daily"]["pm10"].length
+      ){break;}
+      //pm2,5
+        AqiType pm2_5 = AqiType(
+        avg: json["data"]["forecast"]["daily"]["pm25"][i+2]["avg"],
+        min: json["data"]["forecast"]["daily"]["pm25"][i+2]["min"],
+        max: json["data"]["forecast"]["daily"]["pm25"][i+2]["max"],
+      );
+
+      //pm10
+        AqiType pm10 = AqiType(
+        avg: json["data"]["forecast"]["daily"]["pm10"][i+2]["avg"],
+        min: json["data"]["forecast"]["daily"]["pm10"][i+2]["min"],
+        max: json["data"]["forecast"]["daily"]["pm10"][i+2]["max"],
+      );
+
+      forecastDays.add(ForecastDay(date: date, pm2_5: pm2_5, pm10: pm10));
+    }
+    return forecastDays;
+}
 
 
+AqiStyle get style => AqiStyle.fromAqi(general);
 
+}
 
+///A specific [date] of avg,min,max air qualities for different [AqiType]:s
+class ForecastDay {
+  final String date;
+  final AqiType pm2_5;
+  final AqiType pm10;
+  ForecastDay({required this.date, required this.pm2_5,required this.pm10 });
+}
+
+///A specific intance of recorded avg,min,values for an air quality metri (pm2,5 pm10 etc). 
+class AqiType{
+  final int avg;
+  final int min;
+  final int max;
+  AqiType({required this.avg,required this.min,required this.max});
 }

--- a/group7/test/features/current_aqi/aqi_model_test.dart
+++ b/group7/test/features/current_aqi/aqi_model_test.dart
@@ -1,0 +1,93 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:group7/features/current_aqi/aqi_model.dart';
+import 'dummy_aqi_response.dart';
+
+void main() {
+  group("AqiModel Tests", () {
+      
+      test("fromJson  should contain general with correct value", () {
+        
+        final model = AqiModel.fromJson(dummyAqiResponse);
+        expect(model.general, 9);
+      
+      });
+      test("fromJson should contain pm2.5 with correct value", () {
+        
+        final model = AqiModel.fromJson(dummyAqiResponse);
+        expect(model.pm2_5, 9);
+      
+      });
+
+      test("fromJson  should contain pm10 with correct value", () {
+        
+        final model = AqiModel.fromJson(dummyAqiResponse);
+        expect(model.pm10, 8);
+      
+      });
+
+      test("fromJson should contain city with correct value", () {
+        
+        final model = AqiModel.fromJson(dummyAqiResponse);
+        expect(model.city, "Göteborg Femman, Sweden");
+      
+      });
+
+      test("fromJson should contain the pm2.5 forecast (avg,min,max,day) with correct values", () {
+        final model = AqiModel.fromJson(dummyAqiResponse);
+        
+        //Today 
+        expect(model.threeDayForecast[0].date, "2026-04-28");
+        expect(model.threeDayForecast[0].pm2_5.avg, 11);
+        expect(model.threeDayForecast[0].pm2_5.min, 5);
+        expect(model.threeDayForecast[0].pm2_5.max, 17);
+
+        //Next day
+        expect(model.threeDayForecast[1].date, "2026-04-29");
+        expect(model.threeDayForecast[1].pm2_5.avg, 19);
+        expect(model.threeDayForecast[1].pm2_5.min, 9);
+        expect(model.threeDayForecast[1].pm2_5.max, 24);
+
+        //Second day
+        expect(model.threeDayForecast[2].date, "2026-04-30");
+        expect(model.threeDayForecast[2].pm2_5.avg, 18);
+        expect(model.threeDayForecast[2].pm2_5.min, 11);
+        expect(model.threeDayForecast[2].pm2_5.max, 25);
+
+        //Third day
+        expect(model.threeDayForecast[3].date, "2026-05-01");
+        expect(model.threeDayForecast[3].pm2_5.avg, 17);
+        expect(model.threeDayForecast[3].pm2_5.min, 8);
+        expect(model.threeDayForecast[3].pm2_5.max, 31);
+      });
+
+      test("fromJson should contain the pm10 forecast (avg,min,max,day) with correct values", () {
+        final model = AqiModel.fromJson(dummyAqiResponse);
+        
+        //Today 
+        expect(model.threeDayForecast[0].date, "2026-04-28");
+        expect(model.threeDayForecast[0].pm10.avg, 5);
+        expect(model.threeDayForecast[0].pm10.min, 3);
+        expect(model.threeDayForecast[0].pm10.max, 7);
+
+        //Next day
+        expect(model.threeDayForecast[1].date, "2026-04-29");
+        expect(model.threeDayForecast[1].pm10.avg, 13);
+        expect(model.threeDayForecast[1].pm10.min, 5);
+        expect(model.threeDayForecast[1].pm10.max, 18);
+
+        //Second day
+        expect(model.threeDayForecast[2].date, "2026-04-30");
+        expect(model.threeDayForecast[2].pm10.avg, 10);
+        expect(model.threeDayForecast[2].pm10.min, 8);
+        expect(model.threeDayForecast[2].pm10.max, 16);
+
+        //Third day
+        expect(model.threeDayForecast[3].date, "2026-05-01");
+        expect(model.threeDayForecast[3].pm10.avg, 8);
+        expect(model.threeDayForecast[3].pm10.min, 5);
+        expect(model.threeDayForecast[3].pm10.max, 13);
+      });
+
+
+  });
+}

--- a/group7/test/features/current_aqi/dummy_aqi_response.dart
+++ b/group7/test/features/current_aqi/dummy_aqi_response.dart
@@ -1,0 +1,270 @@
+const dummyAqiResponse = {
+  "status": "ok",
+  "data": {
+    "aqi": 9,
+    "idx": 7863,
+    "attributions": [
+      {
+        "url": "http://www.eea.europa.eu/themes/air/",
+        "name": "European Environment Agency",
+        "logo": "Europe-EEA.png"
+      },
+      {
+        "url": "http://worldweather.wmo.int",
+        "name": "World Meteorological Organization - surface synoptic observations (WMO-SYNOP)"
+      },
+      {
+        "url": "http://www.goteborg.se/",
+        "name": "City of Göteborg (Göteborgs Stad)",
+        "logo": "Sweden-goteborg.png"
+      },
+      {
+        "url": "https://waqi.info/",
+        "name": "World Air Quality Index Project"
+      }
+    ],
+    "city": {
+      "geo": [57.7090200428988, 11.9702405180056],
+      "name": "Göteborg Femman, Sweden",
+      "url": "https://aqicn.org/city/sweden/goteborg-femman",
+      "location": ""
+    },
+    "dominentpol": "pm25",
+    "iaqi": {
+      "dew": {
+        "v": -4.5
+      },
+      "h": {
+        "v": 36.5
+      },
+      "no2": {
+        "v": 3
+      },
+      "p": {
+        "v": 1030
+      },
+      "pm10": {
+        "v": 8
+      },
+      "pm25": {
+        "v": 9
+      },
+      "t": {
+        "v": 9.5
+      },
+      "w": {
+        "v": 3.8
+      },
+      "wg": {
+        "v": 18
+      }
+    },
+    "time": {
+      "s": "2026-04-28 10:00:00",
+      "tz": "+02:00",
+      "v": 1777370400,
+      "iso": "2026-04-28T10:00:00+02:00"
+    },
+    "forecast": {
+      "daily": {
+        "o3": [
+          {
+            "avg": 17,
+            "day": "2026-04-26",
+            "max": 20,
+            "min": 12
+          },
+          {
+            "avg": 16,
+            "day": "2026-04-27",
+            "max": 20,
+            "min": 9
+          },
+          {
+            "avg": 15,
+            "day": "2026-04-28",
+            "max": 20,
+            "min": 10
+          },
+          {
+            "avg": 10,
+            "day": "2026-04-29",
+            "max": 19,
+            "min": 6
+          },
+          {
+            "avg": 10,
+            "day": "2026-04-30",
+            "max": 15,
+            "min": 7
+          },
+          {
+            "avg": 14,
+            "day": "2026-05-01",
+            "max": 18,
+            "min": 4
+          },
+          {
+            "avg": 17,
+            "day": "2026-05-02",
+            "max": 22,
+            "min": 13
+          },
+          {
+            "avg": 19,
+            "day": "2026-05-03",
+            "max": 19,
+            "min": 11
+          }
+        ],
+        "pm10": [
+          {
+            "avg": 3,
+            "day": "2026-04-26",
+            "max": 6,
+            "min": 2
+          },
+          {
+            "avg": 5,
+            "day": "2026-04-27",
+            "max": 6,
+            "min": 3
+          },
+          {
+            "avg": 5,
+            "day": "2026-04-28",
+            "max": 7,
+            "min": 3
+          },
+          {
+            "avg": 13,
+            "day": "2026-04-29",
+            "max": 18,
+            "min": 5
+          },
+          {
+            "avg": 10,
+            "day": "2026-04-30",
+            "max": 16,
+            "min": 8
+          },
+          {
+            "avg": 8,
+            "day": "2026-05-01",
+            "max": 13,
+            "min": 5
+          },
+          {
+            "avg": 9,
+            "day": "2026-05-02",
+            "max": 12,
+            "min": 5
+          },
+          {
+            "avg": 11,
+            "day": "2026-05-03",
+            "max": 11,
+            "min": 8
+          }
+        ],
+        "pm25": [
+          {
+            "avg": 5,
+            "day": "2026-04-26",
+            "max": 9,
+            "min": 2
+          },
+          {
+            "avg": 8,
+            "day": "2026-04-27",
+            "max": 15,
+            "min": 5
+          },
+          {
+            "avg": 11,
+            "day": "2026-04-28",
+            "max": 17,
+            "min": 5
+          },
+          {
+            "avg": 19,
+            "day": "2026-04-29",
+            "max": 24,
+            "min": 9
+          },
+          {
+            "avg": 18,
+            "day": "2026-04-30",
+            "max": 25,
+            "min": 11
+          },
+          {
+            "avg": 17,
+            "day": "2026-05-01",
+            "max": 31,
+            "min": 8
+          },
+          {
+            "avg": 30,
+            "day": "2026-05-02",
+            "max": 47,
+            "min": 16
+          },
+          {
+            "avg": 45,
+            "day": "2026-05-03",
+            "max": 45,
+            "min": 32
+          }
+        ],
+        "uvi": [
+          {
+            "avg": 1,
+            "day": "2026-04-26",
+            "max": 4,
+            "min": 0
+          },
+          {
+            "avg": 1,
+            "day": "2026-04-27",
+            "max": 4,
+            "min": 0
+          },
+          {
+            "avg": 1,
+            "day": "2026-04-28",
+            "max": 4,
+            "min": 0
+          },
+          {
+            "avg": 1,
+            "day": "2026-04-29",
+            "max": 4,
+            "min": 0
+          },
+          {
+            "avg": 1,
+            "day": "2026-04-30",
+            "max": 4,
+            "min": 0
+          },
+          {
+            "avg": 1,
+            "day": "2026-05-01",
+            "max": 4,
+            "min": 0
+          },
+          {
+            "avg": 1,
+            "day": "2026-05-02",
+            "max": 4,
+            "min": 0
+          }
+        ]
+      }
+    },
+    "debug": {
+      "sync": "2026-04-28T17:59:29+09:00"
+    }
+  }
+};


### PR DESCRIPTION
!!! Only model/backend use model.threeDayForecast to get data for frontend!!! 
-Added a new List in AQI model containing today + 3 other days forecast (min-,max,- avg values) of pm2,5 and pm10
-Added tests for AQI-model
-Added dummy_api_response - for the AQI_model tests